### PR TITLE
Use ordinary `mount` rather than `pmount`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Package: automount
 Architecture: all
 Depends: ${misc:Depends},
          udev,
-         pmount,
 Description: Automatic mounting of USB devices
  udev rules to automatically mount USB devices into a sane location on
  appearance of the corresponding block devices.

--- a/mounting_script.sh
+++ b/mounting_script.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-
-pmount --exec /dev/$1
+mkdir -p /media/$1
+fsck -p /dev/$1
+mount -o noatime,sync /dev/$1 /media/$1


### PR DESCRIPTION
Unfortunately `pmount` is "difficult" about mounting with the ability to exec
files - since the udev rule runs as root, we can just fall back to `mount`
here.

Also taking the opportunity to mount with `noatime` and `sync` to reduce the
potential damage done when unsafely unmounting.